### PR TITLE
Add secret.yml to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ pickle-email-*.html
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
-config/secrets.yml
 
 ## Environment normalisation:
 /.bundle

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: 79d74e97e2f6caa91a6f6502abaab958ed2b63aaf83a99cc5fb7cfe73e333be7e67b4b87dce2f81358b25ff25091d8df71593170658bdaf17fc7b8221f9085a3
+
+test:
+  secret_key_base: aae8dac6ae010000f7b63183c01e447fe917202239749babb2c66ef1eceae82285a99b461a91123131bfecdf1c90085b270cfe46acf863e8432519d7a62e1d97
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY"] %>


### PR DESCRIPTION
Ok. This seems perfectly safe to me. You should never check in
production sercrets and so I am not. This file contains arbitrary tokens
for development and testing, but not for production. That should make it
easier to do automated testing and deploy to heroku.
